### PR TITLE
Lower deployment target to macOS 14 and aligned releases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,11 @@ import PackageDescription
 let package = Package(
     name: "swift-embeddings",
     platforms: [
-        .macOS(.v15),
-        .iOS(.v18),
-        .tvOS(.v18),
-        .visionOS(.v2),
-        .watchOS(.v11),
+        .macOS(.v14),
+        .iOS(.v17),
+        .tvOS(.v17),
+        .visionOS(.v1),
+        .watchOS(.v10),
     ],
     products: [
         .executable(

--- a/Sources/Embeddings/Bert/BertModel.swift
+++ b/Sources/Embeddings/Bert/BertModel.swift
@@ -5,6 +5,7 @@ import MLTensorUtils
 
 public enum Bert {}
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct ModelConfig: Codable {
         public var modelType: String
@@ -50,6 +51,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct Pooler: Sendable {
         let dense: MLTensorUtils.Layer
@@ -66,6 +68,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct Embeddings: Sendable {
         let wordEmbeddings: MLTensorUtils.Layer
@@ -113,6 +116,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct Output: Sendable {
         let dense: MLTensorUtils.Layer
@@ -137,6 +141,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct Intermediate: Sendable {
         let dense: MLTensorUtils.Layer
@@ -152,6 +157,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct SelfOutput: Sendable {
         let dense: MLTensorUtils.Layer
@@ -176,6 +182,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct SelfAttention: Sendable {
         let query: MLTensorUtils.Layer
@@ -232,6 +239,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct Attention: Sendable {
         let selfAttention: Bert.SelfAttention
@@ -261,6 +269,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct Layer: Sendable {
         let attention: Bert.Attention
@@ -296,6 +305,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct Encoder: Sendable {
         let layers: [Bert.Layer]
@@ -320,6 +330,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct Model: Sendable {
         let embeddings: Bert.Embeddings
@@ -355,6 +366,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public struct ModelBundle: Sendable {
         public let model: Bert.Model

--- a/Sources/Embeddings/Bert/BertUtils.swift
+++ b/Sources/Embeddings/Bert/BertUtils.swift
@@ -5,12 +5,14 @@ import MLTensorUtils
 import Safetensors
 @preconcurrency import Tokenizers
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public static func loadConfig(at url: URL) throws -> Bert.ModelConfig {
         try loadConfigFromFile(at: url)
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public static func loadModelBundle(
         from hubRepoId: String,
@@ -46,6 +48,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     // NOTE: this is a simple key transformation that is required for the Google BERT weights.
     // Model available here: [google-bert/bert-base-uncased](https://huggingface.co/google-bert/bert-base-uncased)
@@ -56,6 +59,7 @@ extension Bert {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Bert {
     public static func loadModel(
         weightsUrl: URL,

--- a/Sources/Embeddings/Clip/ClipModel.swift
+++ b/Sources/Embeddings/Clip/ClipModel.swift
@@ -5,6 +5,7 @@ import MLTensorUtils
 
 public enum Clip {}
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct TextConfig: Codable {
         public var numHiddenLayers: Int
@@ -35,6 +36,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct VisionConfig: Codable {
         public var numHiddenLayers: Int
@@ -68,6 +70,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct ModelConfig: Codable {
         public var textConfig: TextConfig
@@ -86,6 +89,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct Embeddings: Sendable {
         let tokenEmbedding: MLTensorUtils.Layer
@@ -108,6 +112,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct MLP: Sendable {
         let fc1: MLTensorUtils.Layer
@@ -129,6 +134,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct Attention: Sendable {
         let qProj: MLTensorUtils.Layer
@@ -180,6 +186,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct EncoderLayer: Sendable {
         let selfAttnention: Attention
@@ -213,6 +220,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct Encoder: Sendable {
         let layers: [EncoderLayer]
@@ -234,6 +242,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct TextModel: Sendable {
         let embeddings: Embeddings
@@ -268,6 +277,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public struct ModelBundle: Sendable {
         public let textModel: Clip.TextModel

--- a/Sources/Embeddings/Clip/ClipUtils.swift
+++ b/Sources/Embeddings/Clip/ClipUtils.swift
@@ -4,12 +4,14 @@ import Hub
 import MLTensorUtils
 import Safetensors
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public static func loadConfig(at url: URL) throws -> Clip.ModelConfig {
         try loadConfigFromFile(at: url)
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public static func loadModelBundle(
         from hubRepoId: String,
@@ -45,6 +47,7 @@ extension Clip {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Clip {
     public static func loadModel(
         weightsUrl: URL,

--- a/Sources/Embeddings/Model2Vec/Model2VecModel.swift
+++ b/Sources/Embeddings/Model2Vec/Model2VecModel.swift
@@ -14,6 +14,7 @@ extension Model2Vec {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Model2Vec {
     public struct ModelBundle: Sendable {
         public let model: Model2Vec.Model
@@ -65,6 +66,7 @@ extension Model2Vec {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Model2Vec {
     public struct Model: Sendable {
         public let embeddings: MLTensor

--- a/Sources/Embeddings/Model2Vec/Model2VecUtils.swift
+++ b/Sources/Embeddings/Model2Vec/Model2VecUtils.swift
@@ -5,12 +5,14 @@ import MLTensorUtils
 import Safetensors
 @preconcurrency import Tokenizers
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Model2Vec {
     public static func loadConfig(at url: URL) throws -> Model2Vec.ModelConfig {
         try loadConfigFromFile(at: url)
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Model2Vec {
     public static func loadModelBundle(
         from hubRepoId: String,
@@ -49,6 +51,7 @@ extension Model2Vec {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Model2Vec {
     public static func loadModel(
         weightsUrl: URL,

--- a/Sources/Embeddings/Tokenizer/ClipTokenizer.swift
+++ b/Sources/Embeddings/Tokenizer/ClipTokenizer.swift
@@ -3,6 +3,7 @@ import Synchronization
 
 extension Regex: @retroactive @unchecked Sendable {}
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 final class ClipTokenizer: Sendable {
     let bos: String
     let bosToken: Int
@@ -123,6 +124,7 @@ final class ClipTokenizer: Sendable {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension ClipTokenizer: TextTokenizer {
     var unknownTokenId: Int? {
         unkToken
@@ -142,6 +144,7 @@ extension ClipTokenizer: TextTokenizer {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 func loadClipTokenizer(at url: URL) throws -> ClipTokenizer {
     let mergesData = try String(
         contentsOf: url.appendingPathComponent("merges.txt"),
@@ -163,10 +166,12 @@ func loadClipTokenizer(at url: URL) throws -> ClipTokenizer {
     return try ClipTokenizer(bpeRanks: bpeRanks, vocab: vocab)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 func uniquePairs(from arr: [String]) -> Set<Pair<String>> {
     Set(zip(arr, arr.dropFirst()).map { Pair($0) })
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 func findLowestMergePair(
     in keySet: Set<Pair<String>>,
     using bpeRanks: [Pair<String>: Int]

--- a/Sources/Embeddings/Tokenizer/XLMRobetaTokenizer.swift
+++ b/Sources/Embeddings/Tokenizer/XLMRobetaTokenizer.swift
@@ -2,6 +2,7 @@ import Foundation
 import SentencepieceTokenizer
 import Synchronization
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 final class XLMRobetaTokenizer: Sendable {
     /// TODO: Make `SentencepieceTokenizer` conform to `Sendable`
     private let tokenizer: Mutex<SentencepieceTokenizer>
@@ -92,6 +93,7 @@ final class XLMRobetaTokenizer: Sendable {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRobetaTokenizer: TextTokenizer {
     var unknownTokenId: Int? {
         unkTokenId

--- a/Sources/Embeddings/Word2Vec/Word2VecModel.swift
+++ b/Sources/Embeddings/Word2Vec/Word2VecModel.swift
@@ -4,6 +4,7 @@ import MLTensorUtils
 
 public enum Word2Vec {}
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Word2Vec {
     public struct ModelBundle: Sendable {
         public let keyToIndex: [String: Int]

--- a/Sources/Embeddings/Word2Vec/Word2VecUtils.swift
+++ b/Sources/Embeddings/Word2Vec/Word2VecUtils.swift
@@ -3,6 +3,7 @@ import Foundation
 import Hub
 import MLTensorUtils
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension Word2Vec {
     public static func loadModelBundle(
         from hubRepoId: String,

--- a/Sources/Embeddings/XLMRoberta/XLMRobertaModel.swift
+++ b/Sources/Embeddings/XLMRoberta/XLMRobertaModel.swift
@@ -5,6 +5,7 @@ import MLTensorUtils
 
 public enum XLMRoberta {}
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct ModelConfig: Codable {
         public let hiddenSize: Int
@@ -59,6 +60,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct Pooler: Sendable {
         let dense: MLTensorUtils.Layer
@@ -75,6 +77,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct Embeddings: Sendable {
         let wordEmbeddings: MLTensorUtils.Layer
@@ -131,6 +134,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct Intermediate: Sendable {
         let dense: MLTensorUtils.Layer
@@ -146,6 +150,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct SelfOutput: Sendable {
         let dense: MLTensorUtils.Layer
@@ -170,6 +175,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct SelfAttention: Sendable {
         let query: MLTensorUtils.Layer
@@ -233,6 +239,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct Attention: Sendable {
         let selfAttention: XLMRoberta.SelfAttention
@@ -264,6 +271,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct Output: Sendable {
         let dense: MLTensorUtils.Layer
@@ -287,6 +295,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct Layer: Sendable {
         let attention: XLMRoberta.Attention
@@ -324,6 +333,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct Encoder: Sendable {
         let layers: [XLMRoberta.Layer]
@@ -356,6 +366,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct Model: Sendable {
         let embeddings: XLMRoberta.Embeddings
@@ -428,6 +439,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public struct ModelBundle: Sendable {
         public let model: XLMRoberta.Model

--- a/Sources/Embeddings/XLMRoberta/XLMRobertaUtils.swift
+++ b/Sources/Embeddings/XLMRoberta/XLMRobertaUtils.swift
@@ -5,12 +5,14 @@ import MLTensorUtils
 import Safetensors
 @preconcurrency import Tokenizers
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public static func loadConfig(at url: URL) throws -> XLMRoberta.ModelConfig {
         try loadConfigFromFile(at: url)
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public static func loadModelBundle(
         from hubRepoId: String,
@@ -81,6 +83,7 @@ extension XLMRoberta {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension XLMRoberta {
     public static func loadModel(
         weightsUrl: URL,

--- a/Sources/EmbeddingsCLI/Commands/BertCommand.swift
+++ b/Sources/EmbeddingsCLI/Commands/BertCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Embeddings
 import Foundation
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 struct BertCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "bert",

--- a/Sources/EmbeddingsCLI/Commands/ClipCommand.swift
+++ b/Sources/EmbeddingsCLI/Commands/ClipCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Embeddings
 import Foundation
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 struct ClipCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "clip",

--- a/Sources/EmbeddingsCLI/Commands/Model2VecCommand.swift
+++ b/Sources/EmbeddingsCLI/Commands/Model2VecCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Embeddings
 import Foundation
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 struct Model2VecCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "model2vec",

--- a/Sources/EmbeddingsCLI/Commands/Word2VecCommand.swift
+++ b/Sources/EmbeddingsCLI/Commands/Word2VecCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Embeddings
 import Foundation
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 struct Word2VecCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "word2vec",

--- a/Sources/EmbeddingsCLI/Commands/XLMRobertaCommand.swift
+++ b/Sources/EmbeddingsCLI/Commands/XLMRobertaCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Embeddings
 import Foundation
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 struct XLMRobertaCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "xlm-roberta",

--- a/Sources/EmbeddingsCLI/EmbeddingsCLI.swift
+++ b/Sources/EmbeddingsCLI/EmbeddingsCLI.swift
@@ -1,9 +1,9 @@
 import ArgumentParser
 import Foundation
 
-@main
-struct EmbeddingsCLI: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
+private extension CommandConfiguration {
+    static let embeddingsCLISupported = CommandConfiguration(
         abstract: "Encode text using embedding model",
         subcommands: [
             BertCommand.self,
@@ -13,4 +13,31 @@ struct EmbeddingsCLI: AsyncParsableCommand {
             Word2VecCommand.self,
         ]
     )
+}
+
+private extension CommandConfiguration {
+    static let embeddingsCLIUnsupported = CommandConfiguration(
+        abstract: "Encode text using embedding model (requires macOS 15 or later)",
+        subcommands: [
+            UnsupportedStub.self
+        ]
+    )
+}
+
+@main
+struct EmbeddingsCLI: AsyncParsableCommand {
+    static let configuration: CommandConfiguration = {
+        if #available(macOS 15.0, *) {
+            CommandConfiguration.embeddingsCLISupported
+        } else {
+            CommandConfiguration.embeddingsCLIUnsupported
+        }
+    }()
+}
+
+private struct UnsupportedStub: AsyncParsableCommand {
+    func run() async throws {
+        fputs("This command requires macOS 15 or later.\n", stderr)
+        throw ExitCode.failure
+    }
 }

--- a/Sources/EmbeddingsCLI/EmbeddingsCLI.swift
+++ b/Sources/EmbeddingsCLI/EmbeddingsCLI.swift
@@ -27,7 +27,7 @@ private extension CommandConfiguration {
 @main
 struct EmbeddingsCLI: AsyncParsableCommand {
     static let configuration: CommandConfiguration = {
-        if #available(macOS 15.0, *) {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *) {
             CommandConfiguration.embeddingsCLISupported
         } else {
             CommandConfiguration.embeddingsCLIUnsupported

--- a/Sources/EmbeddingsCLI/EmbeddingsCLI.swift
+++ b/Sources/EmbeddingsCLI/EmbeddingsCLI.swift
@@ -2,8 +2,8 @@ import ArgumentParser
 import Foundation
 
 @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
-private extension CommandConfiguration {
-    static let embeddingsCLISupported = CommandConfiguration(
+extension CommandConfiguration {
+    fileprivate static let embeddingsCLISupported = CommandConfiguration(
         abstract: "Encode text using embedding model",
         subcommands: [
             BertCommand.self,
@@ -15,8 +15,8 @@ private extension CommandConfiguration {
     )
 }
 
-private extension CommandConfiguration {
-    static let embeddingsCLIUnsupported = CommandConfiguration(
+extension CommandConfiguration {
+    fileprivate static let embeddingsCLIUnsupported = CommandConfiguration(
         abstract: "Encode text using embedding model (requires macOS 15 or later)",
         subcommands: [
             UnsupportedStub.self

--- a/Sources/MLTensorUtils/Activations.swift
+++ b/Sources/MLTensorUtils/Activations.swift
@@ -7,6 +7,7 @@ public enum GELUApproximation {
 }
 
 // Ref: https://github.com/ml-explore/mlx-swift/blob/86ad75ab1ee96cd70325732b37cd830f87d7e43f/Source/MLXNN/Activations.swift#L659
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func gelu(_ x: MLTensor, approximation: GELUApproximation? = nil) -> MLTensor {
     switch approximation {
     case .none:
@@ -18,11 +19,13 @@ public func gelu(_ x: MLTensor, approximation: GELUApproximation? = nil) -> MLTe
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func sigmoid(_ x: MLTensor) -> MLTensor {
     1 / (1 + (-x).exp())
 }
 
 // Ref: https://en.wikipedia.org/wiki/Error_function#Numerical_approximations
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func erf(_ x: MLTensor) -> MLTensor {
     let a1: Float = 0.254829592
     let a2: Float = -0.284496736

--- a/Sources/MLTensorUtils/Functions.swift
+++ b/Sources/MLTensorUtils/Functions.swift
@@ -1,28 +1,34 @@
 import CoreML
 import Foundation
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func norm(_ x: MLTensor, alongAxes: Int = 1, keepRank: Bool = false) -> MLTensor {
     x.squared().sum(alongAxes: alongAxes, keepRank: keepRank).squareRoot()
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func cosineSimilarity(_ x: MLTensor, _ y: MLTensor, alongAxes: Int = 1) -> MLTensor {
     let normX = norm(x, alongAxes: alongAxes)
     let normY = norm(y, alongAxes: alongAxes)
     return x.matmul(y.transposed()) / (normX * normY)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func dotProduct(_ x: MLTensor, _ y: MLTensor) -> MLTensor {
     x.transposed().matmul(y)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func cosineDistance(_ x: MLTensor, _ y: MLTensor, alongAxes: Int = 1) -> MLTensor {
     1 - cosineSimilarity(x, y, alongAxes: alongAxes)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func euclideanDistance(_ x: MLTensor, _ y: MLTensor, alongAxes: Int = 1) -> MLTensor {
     (x - y).squared().sum(alongAxes: alongAxes).squareRoot()
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func additiveCausalMask<Scalar: MLTensorScalar>(
     _ n: Int32,
     scalarType: Scalar.Type = Float.self

--- a/Sources/MLTensorUtils/Layers.swift
+++ b/Sources/MLTensorUtils/Layers.swift
@@ -1,13 +1,16 @@
 import CoreML
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public typealias Layer = @Sendable (MLTensor) -> MLTensor
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func embedding(weight: MLTensor) -> Layer {
     { x in
         weight.gathering(atIndices: x, alongAxis: 0)
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func linear(weight: MLTensor, bias: MLTensor? = nil) -> Layer {
     { x in
         if let bias {
@@ -18,6 +21,7 @@ public func linear(weight: MLTensor, bias: MLTensor? = nil) -> Layer {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 public func layerNorm(weight: MLTensor, bias: MLTensor, epsilon: Float) -> Layer {
     { x in
         let mean = x.mean(alongAxes: -1, keepRank: true)

--- a/Sources/TestingUtils/TestingUtils.swift
+++ b/Sources/TestingUtils/TestingUtils.swift
@@ -2,6 +2,7 @@ import CoreML
 import Numerics
 import Testing
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension MLTensor {
     package func scalars<Scalar>(
         of scalarType: Scalar.Type
@@ -10,6 +11,7 @@ extension MLTensor {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 extension MLTensor {
     package static func float(shape: [Int]) -> MLTensor {
         let count = shape.reduce(1, *)

--- a/Tests/AccuracyTests/AccuracyTests.swift
+++ b/Tests/AccuracyTests/AccuracyTests.swift
@@ -58,6 +58,7 @@ enum ModelType: String {
 @Suite struct AccuracyTests {
     let cacheDirectory = FileManager.default.temporaryDirectory
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test(
         "Bert Accuracy",
         .enabled(if: ProcessInfo.processInfo.environment["UV_PATH"] != nil)
@@ -82,6 +83,7 @@ enum ModelType: String {
         #expect(allClose(pythonData, swiftData, absoluteTolerance: 1e-5) == true)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test(
         "Clip Accuracy",
         .enabled(if: ProcessInfo.processInfo.environment["UV_PATH"] != nil)
@@ -111,6 +113,7 @@ enum ModelType: String {
         #expect(allClose(pythonData, swiftData, absoluteTolerance: 1e-5) == true)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test(
         "XLM Roberta Accuracy",
         .enabled(if: ProcessInfo.processInfo.environment["UV_PATH"] != nil)
@@ -134,6 +137,7 @@ enum ModelType: String {
         #expect(allClose(pythonData, swiftData, absoluteTolerance: 1e-5) == true)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test(
         "Model2Vec Accuracy",
         .enabled(if: ProcessInfo.processInfo.environment["UV_PATH"] != nil)

--- a/Tests/EmbeddingsTests/BertTests.swift
+++ b/Tests/EmbeddingsTests/BertTests.swift
@@ -7,6 +7,7 @@ import XCTest
 @testable import Embeddings
 
 struct BertTests {
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test func pooler() async {
         let pooler1 = Bert.Pooler(
             dense: MLTensorUtils.linear(
@@ -37,6 +38,7 @@ struct BertTests {
         #expect(allClose(data2, [1, 1, 1, 1, 1]) == true)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test func intermediate() async {
         let intermediate1 = Bert.Intermediate(
             dense: MLTensorUtils.linear(
@@ -67,6 +69,7 @@ struct BertTests {
         #expect(allClose(data2, [5.0, 15.0, 14.0, 51.0]) == true)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test func output() async {
         let output1 = Bert.Output(
             dense: MLTensorUtils.linear(
@@ -120,6 +123,7 @@ struct BertTests {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 final class BertEmbeddingTests: XCTestCase {
     // NOTE: this test is not stable when running using `Testing` library, not sure why
     func testEmbeddings() async {

--- a/Tests/EmbeddingsTests/TokenizerTests.swift
+++ b/Tests/EmbeddingsTests/TokenizerTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Embeddings
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func clipTokenizer() throws {
     let bundleUrl = Bundle.module
         .url(forResource: "merges", withExtension: "txt", subdirectory: "Resources")?

--- a/Tests/EmbeddingsTests/UtilsTests.swift
+++ b/Tests/EmbeddingsTests/UtilsTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Embeddings
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func googleWeightsKeyTransform() async {
     #expect(Bert.googleWeightsKeyTransform("some.weight.key") == "bert.some.weight.key")
     #expect(Bert.googleWeightsKeyTransform("some.LayerNorm.weight") == "bert.some.LayerNorm.gamma")

--- a/Tests/EmbeddingsTests/Word2VecTests.swift
+++ b/Tests/EmbeddingsTests/Word2VecTests.swift
@@ -6,6 +6,7 @@ import TestingUtils
 @testable import Embeddings
 
 struct Word2VecTests {
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test func mostSimilar() async {
         let modelBundle = Word2Vec.ModelBundle(
             keyToIndex: ["a": 0, "b": 1, "c": 2, "d": 3],
@@ -25,6 +26,7 @@ struct Word2VecTests {
         #expect(allClose(scores2, [0.9994259]) == true)
     }
 
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
     @Test func encode() async throws {
         let modelBundle = Word2Vec.ModelBundle(
             keyToIndex: ["a": 0, "b": 1, "c": 2, "d": 3],

--- a/Tests/MLTensorUtilsTests/ActivationTests.swift
+++ b/Tests/MLTensorUtilsTests/ActivationTests.swift
@@ -5,6 +5,7 @@ import TestingUtils
 
 @testable import MLTensorUtils
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func erf() async {
     let input1 = MLTensor(shape: [1], scalars: [0], scalarType: Float.self)
     let result1 = await erf(input1).shapedArray(of: Float.self).scalars
@@ -32,6 +33,7 @@ import TestingUtils
     #expect(allClose(result4, expected4) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func gelu() async {
     let input1 = MLTensor(shape: [1], scalars: [0], scalarType: Float.self)
     let result1 = await gelu(input1).shapedArray(of: Float.self).scalars
@@ -54,6 +56,7 @@ import TestingUtils
     #expect(allClose(result4, expected4) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func geluApproximationFast() async {
     let input1 = MLTensor(shape: [1], scalars: [0], scalarType: Float.self)
     let result1 = await gelu(input1, approximation: .fast).shapedArray(of: Float.self).scalars
@@ -76,6 +79,7 @@ import TestingUtils
     #expect(allClose(result4, expected4) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func geluApproximationPrecise() async {
     let input1 = MLTensor(shape: [1], scalars: [0], scalarType: Float.self)
     let result1 = await gelu(input1, approximation: .precise).shapedArray(of: Float.self).scalars

--- a/Tests/MLTensorUtilsTests/FunctionTests.swift
+++ b/Tests/MLTensorUtilsTests/FunctionTests.swift
@@ -5,6 +5,7 @@ import TestingUtils
 
 @testable import MLTensorUtils
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func additiveCasualMask() async {
     let result = additiveCausalMask(3)
 
@@ -14,6 +15,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func norm() async {
     let x = MLTensor(
         shape: [2, 3],
@@ -28,6 +30,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func cosineSimilarity1D() async {
     let x = MLTensor(
         shape: [1, 6],
@@ -47,6 +50,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func cosineSimilarity2D() async {
     let x = MLTensor(
         shape: [2, 3],
@@ -66,6 +70,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func cosineSimilaritySameTensor() async {
     let x = MLTensor(
         shape: [2, 3],
@@ -80,6 +85,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func dotProduct1D() async {
     let x = MLTensor(
         shape: [6],
@@ -99,6 +105,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func dotProduct2D() async {
     let x = MLTensor(
         shape: [2, 2],
@@ -118,6 +125,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func euclideanDistance1D() async {
     let x = MLTensor(
         shape: [6],
@@ -137,6 +145,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func euclideanDistance2D() async {
     let x = MLTensor(
         shape: [2, 2],
@@ -156,6 +165,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func euclideanDistanceSameTensor() async {
     let x = MLTensor(
         shape: [6],

--- a/Tests/MLTensorUtilsTests/LayerTests.swift
+++ b/Tests/MLTensorUtilsTests/LayerTests.swift
@@ -5,6 +5,7 @@ import TestingUtils
 
 @testable import MLTensorUtils
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func embeddingLayer1D() async {
     let embedding = embedding(weight: MLTensor.float(shape: [12]))
     let result = embedding(MLTensor([0, 2, 4] as [Int32]))
@@ -14,6 +15,7 @@ import TestingUtils
     #expect(resultArray == [0, 2, 4])
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func embeddingLayer2D() async {
     let embedding = embedding(weight: MLTensor.float(shape: [6, 2]))
     let result = embedding(MLTensor([0, 2, 4] as [Int32]))
@@ -23,6 +25,7 @@ import TestingUtils
     #expect(resultArray == [0, 1, 4, 5, 8, 9])
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func embeddingLayer3D() async {
     let embedding = embedding(weight: MLTensor.float(shape: [2, 2, 2]))
     let result = embedding(MLTensor([0, 1] as [Int32]))
@@ -32,6 +35,7 @@ import TestingUtils
     #expect(resultArray == [0, 1, 2, 3, 4, 5, 6, 7])
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func layerNorm1D() async {
     let weight = MLTensor(
         shape: [3],
@@ -57,6 +61,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func layerNorm2D() async {
     let weight = MLTensor(
         shape: [2, 3],
@@ -82,6 +87,7 @@ import TestingUtils
     #expect(allClose(resultArray, expectedArray) == true)
 }
 
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, visionOS 2.0, watchOS 11.0, *)
 @Test func layerNorm3D() async {
     let weight = MLTensor(
         shape: [1, 2, 3],


### PR DESCRIPTION
System API used by this package is not available before macOS 15 and aligned releases, so it makes sense for it to require macOS 15 / iOS 18 and later.

However, some projects may want to include new features that are only available in newer OS releases, without actually raising the minimum required OS version.

Unfortunately, the only way this can be done with Swift packages is to lower the platform versions in Package.swift and add `@available` annotations to everything touching API that's not available on previous OS versions.

I know this is not ideal and makes the code look "dirty", but it will allow me to adopt it in a project, and I'm sure many others could benefit from it.