### PR TITLE
feat: Add postProcess pooling support to Bert, Roberta, and XLMRoberta

### DIFF
--- a/Sources/Embeddings/Roberta/RobertaModel.swift
+++ b/Sources/Embeddings/Roberta/RobertaModel.swift
@@ -373,18 +373,20 @@ extension Roberta {
 
         public func encode(
             _ text: String,
-            maxLength: Int = 512
+            maxLength: Int = 512,
+            postProcess: PostProcess? = nil
         ) throws -> MLTensor {
             let tokens = try tokenizer.tokenizeText(text, maxLength: maxLength)
             let inputIds = MLTensor(shape: [1, tokens.count], scalars: tokens)
             let result = model(inputIds: inputIds)
-            return result[0..., 0, 0...]
+            return processResult(result, with: postProcess)
         }
 
         public func batchEncode(
             _ texts: [String],
             padTokenId: Int = 0,
-            maxLength: Int = 512
+            maxLength: Int = 512,
+            postProcess: PostProcess? = nil
         ) throws -> MLTensor {
             let batchTokenizeResult = try tokenizer.tokenizeTextsPaddingToLongest(
                 texts, padTokenId: padTokenId, maxLength: maxLength)
@@ -394,7 +396,8 @@ extension Roberta {
             let attentionMask = MLTensor(
                 shape: batchTokenizeResult.shape,
                 scalars: batchTokenizeResult.attentionMask)
-            return model(inputIds: inputIds, attentionMask: attentionMask)[0..., 0, 0...]
+            let result = model(inputIds: inputIds, attentionMask: attentionMask)
+            return processResult(result, with: postProcess, attentionMask: attentionMask)
         }
     }
 }

--- a/Sources/Embeddings/XLMRoberta/XLMRobertaModel.swift
+++ b/Sources/Embeddings/XLMRoberta/XLMRobertaModel.swift
@@ -450,17 +450,22 @@ extension XLMRoberta {
             self.tokenizer = tokenizer
         }
 
-        public func encode(_ text: String, maxLength: Int = 512) throws -> MLTensor {
+        public func encode(
+            _ text: String,
+            maxLength: Int = 512,
+            postProcess: PostProcess? = nil
+        ) throws -> MLTensor {
             let tokens = try tokenizer.tokenizeText(text, maxLength: maxLength)
             let inputIds = MLTensor(shape: [1, tokens.count], scalars: tokens)
             let result = model(inputIds: inputIds)
-            return result.sequenceOutput[0..., 0, 0...]
+            return processResult(result.sequenceOutput, with: postProcess)
         }
 
         public func batchEncode(
             _ texts: [String],
             padTokenId: Int = 0,
-            maxLength: Int = 512
+            maxLength: Int = 512,
+            postProcess: PostProcess? = nil
         ) throws -> MLTensor {
             let batchTokenizeResult = try tokenizer.tokenizeTextsPaddingToLongest(
                 texts, padTokenId: padTokenId, maxLength: maxLength)
@@ -471,7 +476,7 @@ extension XLMRoberta {
                 shape: batchTokenizeResult.shape,
                 scalars: batchTokenizeResult.attentionMask)
             let result = model(inputIds: inputIds, attentionMask: attentionMask)
-            return result.sequenceOutput[0..., 0, 0...]
+            return processResult(result.sequenceOutput, with: postProcess, attentionMask: attentionMask)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds optional `postProcess: PostProcess?` parameter to `encode()` and `batchEncode()` on `Bert.ModelBundle`, `Roberta.ModelBundle`, and `XLMRoberta.ModelBundle`
- Matches the existing API already present on `ModernBert.ModelBundle` and `NomicBert.ModelBundle`
- Default is `nil` which preserves the current CLS-token-only behavior for full backward compatibility

## Motivation

Sentence-transformer models like `all-MiniLM-L6-v2`, `all-mpnet-base-v2`, etc. are trained with **mean pooling** over all token embeddings, not CLS token extraction. Using CLS token produces significantly lower-quality embeddings for these models when used for semantic similarity tasks.

The library already has `PostProcess.meanPool` and `PostProcess.meanPoolAndNormalize` enums plus the `maskedMeanPool()` and `processResult()` utility functions, and ModernBert/NomicBert already support them. This PR extends the same pattern to the three remaining model architectures.

## Changes

| File | Change |
|------|--------|
| `BertModel.swift` | Add `postProcess` param, use `processResult()` |
| `RobertaModel.swift` | Add `postProcess` param, use `processResult()` |
| `XLMRobertaModel.swift` | Add `postProcess` param, use `processResult()` |

## Usage

```swift
// Existing behavior (unchanged):
let embedding = try model.encode("Hello world")  // CLS token

// New: mean pooling (recommended for sentence-transformers):
let embedding = try model.encode("Hello world", postProcess: .meanPoolAndNormalize)

// New: batch with mean pooling + attention mask:
let embeddings = try model.batchEncode(texts, postProcess: .meanPoolAndNormalize)
```

## Test plan

- [x] All 57 existing tests pass
- [x] Build succeeds on macOS
- [x] Default behavior preserved (nil postProcess = CLS token extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)