### PR TITLE
Add batchEncode with postProcess pooling support

### DIFF
--- a/Sources/Embeddings/Roberta/RobertaModel.swift
+++ b/Sources/Embeddings/Roberta/RobertaModel.swift
@@ -373,18 +373,20 @@ extension Roberta {
 
         public func encode(
             _ text: String,
-            maxLength: Int = 512
+            maxLength: Int = 512,
+            postProcess: PostProcess? = nil
         ) throws -> MLTensor {
             let tokens = try tokenizer.tokenizeText(text, maxLength: maxLength)
             let inputIds = MLTensor(shape: [1, tokens.count], scalars: tokens)
             let result = model(inputIds: inputIds)
-            return result[0..., 0, 0...]
+            return processResult(result, with: postProcess)
         }
 
         public func batchEncode(
             _ texts: [String],
             padTokenId: Int = 0,
-            maxLength: Int = 512
+            maxLength: Int = 512,
+            postProcess: PostProcess? = nil
         ) throws -> MLTensor {
             let batchTokenizeResult = try tokenizer.tokenizeTextsPaddingToLongest(
                 texts, padTokenId: padTokenId, maxLength: maxLength)
@@ -394,7 +396,8 @@ extension Roberta {
             let attentionMask = MLTensor(
                 shape: batchTokenizeResult.shape,
                 scalars: batchTokenizeResult.attentionMask)
-            return model(inputIds: inputIds, attentionMask: attentionMask)[0..., 0, 0...]
+            let result = model(inputIds: inputIds, attentionMask: attentionMask)
+            return processResult(result, with: postProcess, attentionMask: attentionMask)
         }
     }
 }

--- a/Sources/Embeddings/XLMRoberta/XLMRobertaModel.swift
+++ b/Sources/Embeddings/XLMRoberta/XLMRobertaModel.swift
@@ -450,17 +450,22 @@ extension XLMRoberta {
             self.tokenizer = tokenizer
         }
 
-        public func encode(_ text: String, maxLength: Int = 512) throws -> MLTensor {
+        public func encode(
+            _ text: String,
+            maxLength: Int = 512,
+            postProcess: PostProcess? = nil
+        ) throws -> MLTensor {
             let tokens = try tokenizer.tokenizeText(text, maxLength: maxLength)
             let inputIds = MLTensor(shape: [1, tokens.count], scalars: tokens)
             let result = model(inputIds: inputIds)
-            return result.sequenceOutput[0..., 0, 0...]
+            return processResult(result.sequenceOutput, with: postProcess)
         }
 
         public func batchEncode(
             _ texts: [String],
             padTokenId: Int = 0,
-            maxLength: Int = 512
+            maxLength: Int = 512,
+            postProcess: PostProcess? = nil
         ) throws -> MLTensor {
             let batchTokenizeResult = try tokenizer.tokenizeTextsPaddingToLongest(
                 texts, padTokenId: padTokenId, maxLength: maxLength)
@@ -471,7 +476,7 @@ extension XLMRoberta {
                 shape: batchTokenizeResult.shape,
                 scalars: batchTokenizeResult.attentionMask)
             let result = model(inputIds: inputIds, attentionMask: attentionMask)
-            return result.sequenceOutput[0..., 0, 0...]
+            return processResult(result.sequenceOutput, with: postProcess, attentionMask: attentionMask)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `batchEncode` method to `NomicBert.ModelBundle` for true batch inference
- Tokenizes multiple texts, pads to longest sequence, runs single model forward pass with attention mask
- Adds `postProcess` and `attentionMask` support to `processResult` for correct mean pooling over padded batches
- Also extends `Bert`, `Roberta`, and `XLMRoberta` ModelBundle with the same `postProcess` pooling support

## Motivation
Sequential `encode()` calls in a loop are the bottleneck for bulk embedding workloads (e.g., reindexing 11k+ documents). `batchEncode` enables a single forward pass for an entire batch, dramatically improving throughput.

## Test plan
- [ ] Verify `batchEncode` produces same embeddings as sequential `encode()` calls for the same inputs
- [ ] Verify batch padding and attention masking work correctly with variable-length inputs
- [ ] Verify existing `encode()` single-text path is unaffected